### PR TITLE
fix(macOS): Enable the linker/trimmer for net6.0-macos

### DIFF
--- a/src/dopes/Uno-dotnet6/DopeTestUno/DopeTestUno.Mobile/DopeTestUno.Mobile.csproj
+++ b/src/dopes/Uno-dotnet6/DopeTestUno/DopeTestUno.Mobile/DopeTestUno.Mobile.csproj
@@ -66,6 +66,7 @@
 		</When>
 		<When Condition="'$(TargetFramework)'=='net6.0-macos'">
 			<PropertyGroup>
+				<TrimMode Condition="'$(Configuration)'=='Release'">link</TrimMode>
 			</PropertyGroup>
 		</When>
 	</Choose>


### PR DESCRIPTION
GitHub Issue (If applicable): #

None specific but it was mentioned in https://github.com/unoplatform/uno/issues/8890#issuecomment-1140358020

## PR Type

- Bugfix

## What is the current behavior?

The Dope's Xamarin.Mac legacy project already has this setting enabled.

However the `net6.0-macos` project does **not** set it.

In order to compare apples-to-apples it's best to share the same
settings between Xamarin.Mac legacy and net6.0-macos.

## What is the new behavior?

Both projects have the linker/trimmer enabled in release mode.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

Enabling the linker/trimmer does more than just removing unused code.
It also optimize the bindings, removing code paths that are not used
inside the app, e.g. removing 32bits code paths on 64bits builds.

It's a good, performance enhancing, setting for release builds so it
make sense to have it set inside samples - leading by example :)
