### PR TITLE
chore: Install Xcode iOS Platforms

### DIFF
--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -233,6 +233,17 @@ jobs:
         with:
           xcode-version: '26.0'
 
+      - name: Download Xcode iOS Platforms (for iOS)
+        if: matrix.platform == 'ios'
+        shell: pwsh
+        run: |
+          Write-Host "Running: xcodebuild -runFirstLaunch"
+          xcodebuild -runFirstLaunch
+          Write-Host "Available Xcode Devices:"
+          xcrun simctl list
+          Write-Host "Installing iOS Platform…"
+          xcodebuild -downloadPlatform iOS
+
       - name: Setup Apple Provisioning
         if: matrix.platform == 'ios'
         uses: ./.github/actions/manual-ios-signing


### PR DESCRIPTION
Context: https://github.com/unoplatform/performance/pull/21
Context: https://github.com/unoplatform/Uno.Gallery/pull/1235

While building #21, I noticed a familiar error message from the iOS **Build and Publish** step:

	Finished external tool execution #1 in 00:00:23.5666847 and with exit code 1.
	<?xml version="1.0" encoding="UTF-8"?>
	<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
	<plist version="1.0">
	<dict>
		<key>com.apple.actool.compilation-results</key>
		<dict>
			<key>output-files</key>
			<array>
				<string>/Users/runner/work/performance/performance/UnoApp_blank_ios/UnoApp_blank_ios/obj/Release/net9.0-ios/ios-arm64/actool/bundle/icon60x60@2x.png</string>
				<string>/Users/runner/work/performance/performance/UnoApp_blank_ios/UnoApp_blank_ios/obj/Release/net9.0-ios/ios-arm64/actool/bundle/icon76x76@2x~ipad.png</string>
				<string>/Users/runner/work/performance/performance/UnoApp_blank_ios/UnoApp_blank_ios/obj/Release/net9.0-ios/ios-arm64/actool/partial-info.plist</string>
			</array>
		</dict>
		<key>com.apple.actool.errors</key>
		<array>
			<dict>
				<key>description</key>
				<string>No simulator runtime version from ["22F77", "22G86", "23B86", "23C54"] available to use with iphonesimulator SDK version 23A339</string>
			</dict>
		</array>
	</dict>
	</plist>
	…
	/Users/runner/work/performance/performance/UnoApp_blank_ios/UnoApp_blank_ios/obj/Release/net9.0-ios/ios-arm64/actool/cloned-assets/Media.xcassets : actool error : No simulator runtime version from ["22F77", "22G86", "23B86", "23C54"] available to use with iphonesimulator SDK version 23A339 [/Users/runner/work/performance/performance/UnoApp_blank_ios/UnoApp_blank_ios/UnoApp_blank_ios.csproj::TargetFramework=net9.0-ios]

@jonpryor isn't sure how "best" to fix this, but *a* fix is to just [kindly request Xcode to install everything][0] via:

	xcodebuild -runFirstLaunch
	xcodebuild -downloadPlatform iOS

This installs all iOS simulators into the currently selected Xcode, at the cost of *time*: running the new "Download Xcode iOS Platform" step added about 10 minutes to the Apple stages on Uno.Gallery CI. There is no reason to expect it to be faster in performance CI.

[0]: https://developer.apple.com/documentation/xcode/downloading-and-installing-additional-xcode-components

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
