### PR TITLE
chore: enable .NET 10 for iOS in daily template size tracking workflow

### DIFF
--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -128,18 +128,15 @@ jobs:
                 }
               }
               
-              # iOS (skip .NET 10 - requires Xcode 26.1 which has simulator runtime issues on GitHub runners)
-              if ($dotnet -ne "10.0") {
-                $matrix.include += @{
-                  description = 'ios'
-                  dotnet = $dotnet
-                  template = $template
-                  platform = 'ios'
-                  runtime = 'mono'
-                  os = 'macos-latest'
-                  framework = "net$dotnet-ios"
-                  rid = 'ios-arm64'
-                }
+              $matrix.include += @{
+                description = 'ios'
+                dotnet = $dotnet
+                template = $template
+                platform = 'ios'
+                runtime = 'mono'
+                os = 'macos-latest'
+                framework = "net$dotnet-ios"
+                rid = 'ios-arm64'
               }
               
               # WebAssembly
@@ -261,11 +258,17 @@ jobs:
           dotnet --version
           dotnet --list-sdks
 
-      - name: Setup Xcode (for iOS)
-        if: matrix.platform == 'ios'
+      - name: Setup Xcode for .NET 9 iOS
+        if: matrix.platform == 'ios' && matrix.dotnet == '9.0'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.0'
+
+      - name: Setup Xcode for .NET 10 iOS
+        if: matrix.platform == 'ios' && matrix.dotnet == '10.0'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.2'
 
       - name: Download Xcode iOS Platforms (for iOS)
         if: matrix.platform == 'ios'


### PR DESCRIPTION
Context: 09c66760d6fc97d2d92abde25e2e8a1afbdbfd00

The comment was:

> skip .NET 10 - requires Xcode 26.1 which has simulator runtime issues on GitHub runners

@jonpryor suspects that the "simulator runtime issues" were addressed in commit 09c66760, and/or the use of `maxim-lobanov/setup-xcode` to provision Xcode 26.0 was the cause, as .NET 10 required Xcode 26.1 and now requires Xcode 26.2.

Update the `Setup Xcode …` step to provision Xcode 26.0 for .NET 9 and Xcode 26.2 for .NET 10 by using `matrix.dotnet` in the conditions.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
