### PR TITLE
chore: enable testing under .NET 11

### DIFF
--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -19,7 +19,7 @@ on:
       dotnet_versions:
         description: 'Comma-separated .NET versions to test (e.g., 9.0,10.0)'
         required: false
-        default: '9.0,10.0'
+        default: '9.0,10.0,11.0'
         type: string
       templates:
         description: 'Comma-separated templates to test (blank,recommended)'
@@ -60,6 +60,12 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Setup .NET 11
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
       - name: Install Uno Templates
         id: install-templates
         shell: pwsh
@@ -85,7 +91,7 @@ jobs:
         id: set-matrix
         shell: pwsh
         run: |
-          $dotnetVersions = "${{ inputs.dotnet_versions || '9.0,10.0' }}".Split(',') | ForEach-Object { $_.Trim() }
+          $dotnetVersions = "${{ inputs.dotnet_versions || '9.0,10.0,11.0' }}".Split(',') | ForEach-Object { $_.Trim() }
           $templates = "${{ inputs.templates || 'blank,recommended' }}".Split(',') | ForEach-Object { $_.Trim() }
           
           $matrix = @{
@@ -105,7 +111,7 @@ jobs:
                 framework = "net$dotnet-android"
                 rid = 'android-arm64'
               }
-              if ($dotnet -eq "10.0") {
+              if ([version]$dotnet -ge [version]"10.0") {
                 $matrix.include += @{
                   description = 'android-naot'
                   dotnet = $dotnet
@@ -265,7 +271,7 @@ jobs:
           xcode-version: '26.0'
 
       - name: Setup Xcode for .NET 10 iOS
-        if: matrix.platform == 'ios' && matrix.dotnet == '10.0'
+        if: matrix.platform == 'ios' && matrix.dotnet != '9.0'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.2'
@@ -338,8 +344,31 @@ jobs:
             "desktop" { "desktop" }
           }
           
-          Write-Host "Creating project with preset: $template, platform: $unoPlatform, tfm: net$dotnetVersion"
-          dotnet new unoapp -o $projectName -preset $template -platforms $unoPlatform -tfm net$dotnetVersion
+          $tfm = "net$dotnetVersion"
+          if ([version]$dotnetVersion -gt [version]"10.0") {
+            $tfm = "net10.0"
+            Write-Host "Using TFM net10.0 when building for .NET 11"
+          }
+
+          Write-Host "Creating project with preset: $template, platform: $unoPlatform, tfm: $tfm"
+          dotnet new unoapp -o $projectName -preset $template -platforms $unoPlatform -tfm $tfm
+
+          if ([version]$dotnetVersion -gt [version]"10.0") {
+            $tfm = "net$dotnetVersion"
+            $projectFile = Get-ChildItem -Path $projectName -Filter "*.csproj" -Exclude "*.Tests.csproj" -Recurse | Select-Object -First 1
+            Write-Host "Updating $($projectFile.FullName) to target $tfm"
+            (Get-Content $projectFile.FullName).Replace("net10.0", $tfm) | Set-Content $projectFile.FullName
+
+            Write-Host "New $($projectFile.FullName) contents:"
+            Get-Content $projectFile.FullName | ForEach-Object { Write-Host $_ }
+
+            $globalJson = Get-ChildItem -Path $projectName -Filter "global.json" -Recurse | Select-Object -First 1
+            Write-Host "Updating $($globalJson.FullName) to allow prerelease"
+            (Get-Content $globalJson.FullName).Replace('"allowPrerelease": false', '"allowPrerelease": true') | Set-Content $globalJson.FullName
+
+            Write-Host "New $($globalJson.FullName) contents:"
+            Get-Content $globalJson.FullName | ForEach-Object { Write-Host $_ }
+          }
           
           echo "PROJECT_PATH=$projectName" >> $env:GITHUB_ENV
           echo "PROJECT_NAME=$projectName" >> $env:GITHUB_ENV
@@ -354,7 +383,7 @@ jobs:
           $dotnetVersion = "${{ matrix.dotnet }}"
           
           # Disable XAML/Resource Trimming for net10 due to https://github.com/unoplatform/uno/issues/21731
-          $enableXamlTrimming = $dotnetVersion -ne "10.0"
+          $enableXamlTrimming = [version]$dotnetVersion -le [version]"10.0"
           
           # Start timing
           $startTime = Get-Date


### PR DESCRIPTION
As we now have three versions under consideration -- .NET 9, .NET 10, .NET 11 -- using string comparisons for version numbers doesn't work.

Instead, we need to use version comparison, which is done by prefixing variables and strings with `[version]` and changing the comparison operand accordingly:

	# old and busted:
	if ($dotnet -eq "10.0")

	# new hotness:
	if ([version]$dotnet -ge [version]"10.0")

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
