### PR TITLE
chore: add .NET 11 + iOS + CoreCLR configuration

### DIFF
--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -144,6 +144,18 @@ jobs:
                 framework = "net$dotnet-ios"
                 rid = 'ios-arm64'
               }
+              if ([version]$dotnet -ge [version]"11.0") {
+                $matrix.include += @{
+                  description = 'ios-coreclr'
+                  dotnet = $dotnet
+                  template = $template
+                  platform = 'ios'
+                  runtime = 'clr'
+                  os = 'macos-latest'
+                  framework = "net$dotnet-ios"
+                  rid = 'ios-arm64'
+                }
+              }
               
               # WebAssembly
               $matrix.include += @{


### PR DESCRIPTION
CoreCLR support is new to iOS in .NET 11 Preview 1.
