### PR TITLE
chore: use `Select-Object -ExpandProperty`, not `Format-Table -AutoSize`

### DIFF
--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -402,7 +402,7 @@ jobs:
           
           # Debug: Show what's in the project directory
           Write-Host "Contents of ${projectPath}:"
-          Get-ChildItem -Path $projectPath -Recurse | Select-Object FullName | Format-Table -AutoSize
+          Get-ChildItem -Path $projectPath -Recurse | Select-Object -ExpandProperty FullName
           
           # Single project structure - find the main .csproj
           $projectFile = Get-ChildItem -Path $projectPath -Filter "*.csproj" -Exclude "*.Tests.csproj" -Recurse | Select-Object -First 1


### PR DESCRIPTION
What do we want?  Based on the existing comment:

	# Debug: Show what's in the project directory
	Write-Host "Contents of ${projectPath}:"
	Get-ChildItem -Path $projectPath -Recurse | Select-Object FullName | Format-Table -Wrap

we want to get all files in the project directory.

What do we *actually* get?  *Truncated* output:

	Contents of UnoApp_recommended_ios:

	FullName
	--------
	/Users/runner/work/performance/performance/UnoApp_recommended_ios/UnoApp_recom…
	/Users/runner/work/performance/performance/UnoApp_recommended_ios/Directory.Bu…
	/Users/runner/work/performance/performance/UnoApp_recommended_ios/Directory.Bu…
	/Users/runner/work/performance/performance/UnoApp_recommended_ios/Directory.Pa…
	…

This is not particularly helpful.

Instead, use [`Format-Table -Wrap`][0]:

> Displays text that exceeds the column width on the next line.
> By default, text that exceeds the column width is truncated.

This should allow us to see the *full* file paths.

[0]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/format-table?view=powershell-7.5#-wrap

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

