### PR TITLE
chore: deduplicate `dotnet publish` logic

### DIFF
--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -414,88 +414,60 @@ jobs:
           
           Write-Host "Found project: $($projectFile.FullName)"
           Write-Host "XAML/Resource Trimming enabled: $enableXamlTrimming"
+
+          $publishArgs = @($projectFile.FullName,
+            '-f', $framework,
+            '-c', 'Release',
+            '-o', 'publish',
+            '/bl:build.binlog')
+
+          $isAot = "${{ matrix.runtime }}" -eq "nativeaot"
+          $useMono = if ("${{ matrix.runtime }}" -eq "mono") { "true" } else { "false" }
+          if ($isAot) {
+            $publishArgs += @('-p:PublishAot=true')
+          } else {
+            $publishArgs += @("-p:UseMonoRuntime=$useMono")
+          }
           
           switch ($platform) {
             "android" {
-              $isAot = "${{ matrix.runtime }}" -eq "nativeaot"
-              
-              if ($isAot) {
-                # Need to use `-r $rid` to avoid: error MSB3030: Could not copy the file "bin/Release/net10.0-android/native/UnoApp_blank_android.so" because it was not found.
-                Write-Host "Building Android AAB for Native AOT..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -r $rid `
-                  -p:PublishAot=true `
-                  -p:AndroidPackageFormat=aab `
-                  -p:AndroidKeyStore=false `
-                  -o publish `
-                  /bl:build.binlog
-              } else {
-                Write-Host "Building Android AAB..."
-                $useMono = if ("${{ matrix.runtime }}" -eq "mono") { "true" } else { "false" }
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -p:UseMonoRuntime=$useMono `
-                  -p:AndroidPackageFormat=aab `
-                  -p:AndroidKeyStore=false `
-                  -o publish `
-                  /bl:build.binlog
-              }
+              Write-Host "Building Android AAB..."
+              $publishArgs += @('-r', $rid,
+                '-p:AndroidPackageFormat=aab',
+                '-p:AndroidKeyStore=false')
             }
             "ios" {
               Write-Host "Building iOS IPA (signed device build)..."
-              dotnet publish $projectFile.FullName `
-                -f $framework `
-                -c Release `
-                -p:RuntimeIdentifier=$rid `
-                -p:ArchiveOnBuild=true `
-                -p:CodesignKey="$env:CODESIGN_KEY" `
-                -p:CodesignProvision="$env:PROVISIONING_UUID" `
-                -p:ApplicationId=uno.platform.performance `
-                -o publish `
-                /bl:build.binlog
+              $publishArgs += @('-r', $rid,
+                "-p:ArchiveOnBuild=true",
+                "-p:CodesignKey=$env:CODESIGN_KEY",
+                "-p:CodesignProvision=$env:PROVISIONING_UUID",
+                "-p:ApplicationId=uno.platform.performance")
             }
             "wasm" {
               Write-Host "Building WebAssembly..."
-              dotnet publish $projectFile.FullName `
-                -f $framework `
-                -c Release `
-                -p:UnoXamlResourcesTrimming=$enableXamlTrimming `
-                -p:UnoEnableXamlTrimming=$enableXamlTrimming `
-                -o publish `
-                /bl:build.binlog
+              $publishArgs += @(
+                "-p:UnoXamlResourcesTrimming=$enableXamlTrimming",
+                "-p:UnoEnableXamlTrimming=$enableXamlTrimming")
             }
             "desktop" {
-              $isAot = "${{ matrix.runtime }}" -eq "nativeaot"
-              
+              $publishArgs += @("-r", $rid,
+                "--self-contained", "true",
+                "-p:PublishTrimmed=true")
+
               if ($isAot) {
                 Write-Host "Building Desktop with Native AOT (self-contained)..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -r $rid `
-                  --self-contained true `
-                  -p:PublishAot=true `
-                  -p:PublishTrimmed=true `
-                  -o publish `
-                  /bl:build.binlog
               } else {
                 Write-Host "Building Desktop (self-contained)..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -r $rid `
-                  --self-contained true `
-                  -p:PublishTrimmed=true `
-                  -p:UnoXamlResourcesTrimming=$enableXamlTrimming `
-                  -p:UnoEnableXamlTrimming=$enableXamlTrimming `
-                  -o publish `
-                  /bl:build.binlog
+                $publishArgs += @(
+                  "-p:UnoXamlResourcesTrimming=$enableXamlTrimming",
+                  "-p:UnoEnableXamlTrimming=$enableXamlTrimming")
               }
             }
           }
+
+          Write-Host "dotnet publish $publishArgs"
+          dotnet publish $publishArgs
           
           $endTime = Get-Date
           $buildTime = ($endTime - $startTime).TotalSeconds


### PR DESCRIPTION
Fixes: https://github.com/unoplatform/performance/issues/31

Context: d6f204bcaef3d37ec147b964e27397a94a645abc

`daily-template-size-tracking.yml` duplicates the build commands for nearly everything:

  * `android` has two build command paths, for `"${{ matrix.runtime }}" -eq "nativeaot"` vs. not.
  * `desktop` also has two build command paths.
  * For both `android` and `desktop`, the "non-nativeaot" paths support CoreCLR as well.
  * `ios` has only one command path, even though .NET 11 adds support for CoreCLR, commit d6f204bc attempted to test that, but it was not actually tested.

Instead of duplicating the complete `dotnet publish` command everywhere, *centralizer* the commands by using PowerShell Arrays. This allows for a single `dotnet publish` invocation, making it easier to add "variants" to `$matrix` and have them built accordingly.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
